### PR TITLE
ポーリング間隔を短縮

### DIFF
--- a/lib/pointcloud_viewer/_internal/server.py
+++ b/lib/pointcloud_viewer/_internal/server.py
@@ -66,7 +66,7 @@ def multiprocessing_worker(
                 data = websocket_broadcasting_queue.get()
                 await websocket_connection.send(data)
             else:
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0.01)
 
     async def __websocket_handler(websocket: websockets.WebSocketServerProtocol, path: str):
         nonlocal websocket_connection


### PR DESCRIPTION
**目的**
ポーリング間隔を10分の1にすることで性能が10倍になる。
さらに10分の1にしても効果は薄い。