### PR TITLE
Fix #44: 高dpiディスプレイでLinesetの描画位置がずれる問題の修正

### DIFF
--- a/client/src/canvas2d.ts
+++ b/client/src/canvas2d.ts
@@ -4,8 +4,10 @@ export class Canvas2D {
   constructor () {
     const canvas = document.createElement('canvas');
     canvas.style.position = 'absolute';
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
+    canvas.style.width = '100vw';
+    canvas.style.height = '100vh';
+    canvas.width = window.innerWidth * window.devicePixelRatio;
+    canvas.height = window.innerHeight * window.devicePixelRatio;
     this.domElement = canvas;
     const ctx = canvas.getContext('2d');
     if (ctx !== null) {
@@ -14,8 +16,8 @@ export class Canvas2D {
       throw Error('cannot initialize canvas context');
     }
     window.addEventListener('resize', () => {
-      this.domElement.width = window.innerWidth;
-      this.domElement.height = window.innerHeight;
+      this.domElement.width = window.innerWidth * window.devicePixelRatio;
+      this.domElement.height = window.innerHeight * window.devicePixelRatio;
     });
   }
 }

--- a/client/src/lineset.ts
+++ b/client/src/lineset.ts
@@ -34,10 +34,10 @@ export class Lineset {
       p0.project(camera);
       p1.project(camera);
 
-      const sx0 = (canvas.domElement.width / 2) * (p0.x + 1.0) / window.devicePixelRatio;
-      const sy0 = (canvas.domElement.height / 2) * (-p0.y + 1.0) / window.devicePixelRatio;
-      const sx1 = (canvas.domElement.width / 2) * (p1.x + 1.0) / window.devicePixelRatio;
-      const sy1 = (canvas.domElement.height / 2) * (-p1.y + 1.0) / window.devicePixelRatio;
+      const sx0 = (canvas.domElement.width / 2) * (p0.x + 1.0);
+      const sy0 = (canvas.domElement.height / 2) * (-p0.y + 1.0);
+      const sx1 = (canvas.domElement.width / 2) * (p1.x + 1.0);
+      const sy1 = (canvas.domElement.height / 2) * (-p1.y + 1.0);
 
       canvas.ctx.save();
 

--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -155,7 +155,7 @@ export class PointCloudViewer {
         for (let i = 0; i < this.overlays.length; i++) {
           this.overlays[i].render(this.renderer.domElement, camera);
         }
-        this.canvas2d.ctx.clearRect(0, 0, this.canvas2d.domElement.clientWidth, this.canvas2d.domElement.clientHeight);
+        this.canvas2d.ctx.clearRect(0, 0, this.canvas2d.domElement.width, this.canvas2d.domElement.height);
         for (let i = 0; i < this.linesets.length; i++) {
           this.linesets[i].render(this.canvas2d, camera);
         }


### PR DESCRIPTION
**修正・解決されるissue**
Fix #44

**変更点**
`window.devicePixelRatio`が1でないディスプレイを使った際、キャンバスのwidth,heightを調整するように修正。

**備考**
高dpiのディスプレイが手元にないのでテストをお願いしたいです
