### PR TITLE
fix: ボタンの名前を幅いっぱいに表示する

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -12,3 +12,7 @@ body {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.cr.function .property-name {
+    width: 100%;
+}


### PR DESCRIPTION
**修正・解決されるissue**
resolve #31

**変更点**
カスタムコントロールの名前の表示幅はデフォルトで `40%` だったが、ボタンについては他に表示するものはないため、ボタンの名前のみ表示幅を `100%` にした。

**確認手順**
以下のように、ボタンのみ表示幅が `100%` になる。
<img width="253" alt="スクリーンショット 2022-01-15 16 35 26" src="https://user-images.githubusercontent.com/43411965/149613886-8fd06410-5a36-4f84-b41a-529172f61857.png">


**確認事項**
 - [x] 修正途中であればDraftになっていますか？
 - [x] タイトルはわかりやすいですか？(何をどうするを書いてください)
 - [x] reviewer assignee は登録してありますか？(両方に @kjfsm, reviewerは必要に応じて追加)