### PR TITLE
fix: websockets.serve における max_size を 2**24 にした

### DIFF
--- a/lib/pointcloud_viewer/_internal/server.py
+++ b/lib/pointcloud_viewer/_internal/server.py
@@ -94,7 +94,7 @@ def multiprocessing_worker(
     start_server = websockets.serve(__websocket_handler,
                                     host=host, 
                                     port=websocket_port,
-                                    max_size=2**24)
+                                    max_size=None)
     loop.run_until_complete(start_server)
 
     threads = [


### PR DESCRIPTION
**修正・解決されるissue**
Fix #38

**目的**
オーバーレイに 1600x800 ぐらいの画像をセットしてからキャプチャをすると `websockets.exceptions.PayloadTooBig` が投げられるので、これを解決する。

**変更点**
`websockets.serve()` における `max_size` がデフォルト値(2**20)だったので、これを `2**24` に変更した。

**備考**
2**24 で本当に良いのかが気になっています。

**確認事項**
 - [x] 修正途中であればDraftになっていますか？
 - [x] タイトルはわかりやすいですか？(何をどうするを書いてください)
 - [x] reviewer assignee は登録してありますか？(両方に @kjfsm, reviewerは必要に応じて追加)