### PR TITLE
カメラのposition,rotation,targetをサーバ側から取得する

### DIFF
--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -204,6 +204,7 @@ export class PointCloudViewer {
       controls.update();
       return controls;
     }
+
     getCameraPosition (): THREE.Vector3 {
       const perspective: boolean = this.config.camera.usePerspective;
       return perspective ? this.perspectiveCamera.position : this.orthographicCamera.position;

--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -204,4 +204,17 @@ export class PointCloudViewer {
       controls.update();
       return controls;
     }
+    getCameraPosition (): THREE.Vector3 {
+      const perspective: boolean = this.config.camera.usePerspective;
+      return perspective ? this.perspectiveCamera.position : this.orthographicCamera.position;
+    }
+
+    getCameraRotation (): THREE.Euler {
+      const perspective: boolean = this.config.camera.usePerspective;
+      return perspective ? this.perspectiveCamera.rotation : this.orthographicCamera.rotation;
+    }
+
+    getCameraTarget (): THREE.Vector3 {
+      return this.controls.target;
+    }
 }

--- a/client/src/websocket/client_command.ts
+++ b/client/src/websocket/client_command.ts
@@ -106,26 +106,26 @@ export function sendKeyPress (websocket: WebSocket, commandID: string, event: Ke
   command.setUuid(commandID);
   websocket.send(command.serializeBinary());
 }
-export function sendCameraPosition (websocket: WebSocket, commandID: string, rawPosition:THREE.Vector3) {
+export function sendCameraPosition (websocket: WebSocket, commandID: string, rawPosition:THREE.Vector3):void {
   const command = new PB.ClientCommand();
   command.setCameraPosition(Vector3toVecXYZf(rawPosition));
   command.setUuid(commandID);
   websocket.send(command.serializeBinary());
 }
-export function sendCameraRotation (websocket: WebSocket, commandID: string, rawRotation:THREE.Vector3) {
+export function sendCameraRotation (websocket: WebSocket, commandID: string, rawRotation:THREE.Vector3):void {
   const command = new PB.ClientCommand();
   command.setCameraRotation(Vector3toVecXYZf(rawRotation));
   command.setUuid(commandID);
   websocket.send(command.serializeBinary());
 }
 
-export function sendCameraTarget (websocket: WebSocket, commandID: string, rawTarget:THREE.Vector3) {
+export function sendCameraTarget (websocket: WebSocket, commandID: string, rawTarget:THREE.Vector3):void {
   const command = new PB.ClientCommand();
   command.setCameraTarget(Vector3toVecXYZf(rawTarget));
   command.setUuid(commandID);
   websocket.send(command.serializeBinary());
 }
-function Vector3toVecXYZf (vector3: THREE.Vector3) {
+function Vector3toVecXYZf (vector3: THREE.Vector3):VecXYZf {
   const vecXYZf = new VecXYZf();
   vecXYZf.setX(vector3.x);
   vecXYZf.setY(vector3.y);

--- a/client/src/websocket/client_command.ts
+++ b/client/src/websocket/client_command.ts
@@ -1,4 +1,6 @@
 import * as PB from '../protobuf/client_pb.js';
+import * as THREE from 'three';
+import { VecXYZf } from '../protobuf/server_pb.js';
 
 export function sendSuccess (websocket: WebSocket, commandID: string, message: string): void {
   const resultSuccess = new PB.Result();
@@ -103,4 +105,30 @@ export function sendKeyPress (websocket: WebSocket, commandID: string, event: Ke
   command.setKeyEventOccurred(keyEventOccurred);
   command.setUuid(commandID);
   websocket.send(command.serializeBinary());
+}
+export function sendCameraPosition (websocket: WebSocket, commandID: string, rawPosition:THREE.Vector3) {
+  const command = new PB.ClientCommand();
+  command.setCameraPosition(Vector3toVecXYZf(rawPosition));
+  command.setUuid(commandID);
+  websocket.send(command.serializeBinary());
+}
+export function sendCameraRotation (websocket: WebSocket, commandID: string, rawRotation:THREE.Vector3) {
+  const command = new PB.ClientCommand();
+  command.setCameraRotation(Vector3toVecXYZf(rawRotation));
+  command.setUuid(commandID);
+  websocket.send(command.serializeBinary());
+}
+
+export function sendCameraTarget (websocket: WebSocket, commandID: string, rawTarget:THREE.Vector3) {
+  const command = new PB.ClientCommand();
+  command.setCameraTarget(Vector3toVecXYZf(rawTarget));
+  command.setUuid(commandID);
+  websocket.send(command.serializeBinary());
+}
+function Vector3toVecXYZf (vector3: THREE.Vector3) {
+  const vecXYZf = new VecXYZf();
+  vecXYZf.setX(vector3.x);
+  vecXYZf.setY(vector3.y);
+  vecXYZf.setZ(vector3.z);
+  return vecXYZf;
 }

--- a/client/src/websocket/handler/get_camera_status.ts
+++ b/client/src/websocket/handler/get_camera_status.ts
@@ -1,0 +1,12 @@
+import { sendCameraPosition, sendCameraRotation, sendCameraTarget } from '../client_command';
+import { PointCloudViewer } from '../../viewer';
+
+export function handleCameraPosition (websocket: WebSocket, commandID: string, viewer: PointCloudViewer): void {
+  sendCameraPosition(websocket, commandID, viewer.getCameraPosition());
+}
+export function handleCameraRotation (websocket: WebSocket, commandID: string, viewer: PointCloudViewer): void {
+  sendCameraRotation(websocket, commandID, viewer.getCameraRotation().toVector3());
+}
+export function handleCameraTarget (websocket: WebSocket, commandID: string, viewer: PointCloudViewer): void {
+  sendCameraTarget(websocket, commandID, viewer.getCameraTarget());
+}

--- a/client/src/websocket/websocket.ts
+++ b/client/src/websocket/websocket.ts
@@ -11,6 +11,7 @@ import { handleRemoveControl } from './handler/remove_control';
 import { handleRemoveObject } from './handler/remove_object';
 import { handleSetCamera } from './handler/set_camera';
 import { handleSetKeyEvent } from './handler/set_key_event';
+import { handleCameraPosition, handleCameraRotation, handleCameraTarget } from './handler/get_camera_status';
 
 export function connectWebSocket (viewer: PointCloudViewer, url: string) {
   const websocket = new WebSocket(url);
@@ -54,6 +55,15 @@ function handleProtobuf (websocket: WebSocket, viewer: PointCloudViewer, message
         break;
       case commandCase.REMOVE_CUSTOM_CONTROL:
         handleRemoveControl(websocket, commandID, viewer, message.getRemoveCustomControl());
+        break;
+      case commandCase.CAMERA_POSITION:
+        handleCameraPosition(websocket, commandID, viewer);
+        break;
+      case commandCase.CAMERA_ROTATION:
+        handleCameraRotation(websocket, commandID, viewer);
+        break;
+      case commandCase.CAMERA_TARGET:
+        handleCameraTarget(websocket, commandID, viewer);
         break;
       default:
         sendFailure(websocket, commandID, 'message has not any command');

--- a/lib/pointcloud_viewer/_internal/members/camera.py
+++ b/lib/pointcloud_viewer/_internal/members/camera.py
@@ -109,3 +109,54 @@ def set_camera_target(
     ret = self._wait_until(uuid)
     if ret.result.HasField("failure"):
         raise RuntimeError(ret.result.failure)
+
+
+def get_camera_position(
+    self: PointCloudViewer,
+) -> server_pb2.VecXYZf:  # debug
+    """ カメラのpositionを取得する.．
+
+    """
+    obj = server_pb2.ServerCommand()
+    obj.camera_position = True
+    uuid = uuid4()
+    self._send_data(obj, uuid)
+    ret = self._wait_until(uuid)
+    if ret.result.HasField("failure"):
+        raise RuntimeError(ret.result.failure)
+    if ret.HasField("camera_position"):
+        return ret.camera_position
+
+
+def get_camera_rotation(
+    self: PointCloudViewer,
+) -> server_pb2.VecXYZf:  # debug
+    """ カメラのrotationを取得する.．
+
+    """
+    obj = server_pb2.ServerCommand()
+    obj.camera_rotation = True
+    uuid = uuid4()
+    self._send_data(obj, uuid)
+    ret = self._wait_until(uuid)
+    if ret.result.HasField("failure"):
+        raise RuntimeError(ret.result.failure)
+    if ret.HasField("camera_rotation"):
+        return ret.camera_rotation
+
+
+def get_camera_target(
+    self: PointCloudViewer,
+) -> server_pb2.VecXYZf:  # debug
+    """ カメラのtargetを取得する.．
+
+    """
+    obj = server_pb2.ServerCommand()
+    obj.camera_target = True
+    uuid = uuid4()
+    self._send_data(obj, uuid)
+    ret = self._wait_until(uuid)
+    if ret.result.HasField("failure"):
+        raise RuntimeError(ret.result.failure)
+    if ret.HasField("camera_target"):
+        return ret.camera_target

--- a/lib/pointcloud_viewer/pointcloud_viewer.py
+++ b/lib/pointcloud_viewer/pointcloud_viewer.py
@@ -4,6 +4,7 @@ import multiprocessing
 from enum import Enum, auto
 from typing import Optional
 
+
 class DownSampleStrategy(Enum):
     NONE = auto()
     RANDOM_SAMPLE = auto()
@@ -14,6 +15,7 @@ class DownSampleStrategy(Enum):
     def set_voxel_size(self, voxel_size):
         self.voxel_size = voxel_size
         return self
+
 
 class PointCloudViewer:
     """点群をブラウザで表示するためのサーバーを立ち上げるビューア。
@@ -36,7 +38,7 @@ class PointCloudViewer:
     _websocket_message_queue: multiprocessing.Queue
 
     from pointcloud_viewer._internal.members.capture_screen import capture_screen
-    from pointcloud_viewer._internal.members.camera import set_camera_position, set_camera_target, set_orthographic_camera, set_perspective_camera
+    from pointcloud_viewer._internal.members.camera import set_camera_position, set_camera_target, set_orthographic_camera, set_perspective_camera, get_camera_position, get_camera_rotation, get_camera_target
     from pointcloud_viewer._internal.members.custom_control import add_custom_button, add_custom_checkbox, add_custom_colorpicker, add_custom_selectbox, add_custom_slider, add_custom_textbox, add_custom_folder, remove_all_custom_controls, remove_custom_control
     from pointcloud_viewer._internal.members.internal_utils import __init__
     from pointcloud_viewer._internal.members.send_object import send_lineset, send_overlay_text, send_overlay_image, send_pointcloud,send_pointcloud_pcd, send_mesh

--- a/protobuf/client.proto
+++ b/protobuf/client.proto
@@ -9,6 +9,9 @@ message ClientCommand {
         Image image = 4;
         ControlChanged control_changed = 5;
         KeyEventOccurred key_event_occurred = 6;
+        VecXYZf camera_position = 7;
+        VecXYZf camera_rotation = 8;
+        VecXYZf camera_target= 9;
     }
 }
 
@@ -46,4 +49,10 @@ message KeyEventOccurred {
         bool metaKey = 6;
         bool repeat = 7;
     }
+}
+
+message VecXYZf {
+    float x = 1;
+    float y = 2;
+    float z = 3;
 }

--- a/protobuf/server.proto
+++ b/protobuf/server.proto
@@ -12,6 +12,9 @@ message ServerCommand {
         SetKeyEventHandler set_key_event_handler = 7;
         RemoveObject remove_object = 8;
         RemoveCustomControl remove_custom_control = 9;
+        bool camera_position = 10;
+        bool camera_rotation = 11;
+        bool camera_target= 12;
     }
 }
 


### PR DESCRIPTION
**修正・解決されるissue**
resolve #34 

**目的**
 - [x] ①カメラのposition,rotation,targetをサーバ側から取得
 - [ ] ②カメラを真上、真横に動かす
 - [ ] ③軸方向に平行移動
 - [ ] ④90°回り込む操作

**変更点**
①カメラのposition,rotation,targetをサーバ側から取得
- サーバからカメラposition・rotation・targetを取得するコードに作成
- position・rotation・target取得用・返却用enumを`server.proto`, `client.proto`に追記
- フロント側で値取得・サーバに返却できるメソッドを作成
 
**確認手順**
①カメラのposition,rotation,targetをサーバ側から取得
main.py内などで，以下のようにviewerのメソッドを呼んでください．
```
print(viewer.get_camera_position())
print(viewer.get_camera_rotation())
print(viewer.get_camera_target())
```
出力例
```
x: 1.5759021043777466
y: 0.5800051689147949
z: 0.4171499013900757

x: -0.9472051858901978
y: 1.1376330852508545
z: 0.20292653143405914

x: 0.003819163190200925
y: -0.01017830241471529
z: -0.007395267486572266
``` 


**備考**


**確認事項**
 - [x] 修正途中であればDraftになっていますか？
 - [x] タイトルはわかりやすいですか？(何をどうするを書いてください)
 - [x] reviewer assignee は登録してありますか？(両方に @kjfsm, reviewerは必要に応じて追加)