### PR TITLE
on_changeにNoneが渡された時の挙動を変更

### DIFF
--- a/lib/cumo/_internal/members/set_custom_control.py
+++ b/lib/cumo/_internal/members/set_custom_control.py
@@ -54,7 +54,8 @@ def set_custom_slider(
     set_custom_control.slider.CopyFrom(slider)
     set_custom_control.target = str(target)
     obj.set_custom_control.CopyFrom(set_custom_control)
-    self._set_custom_handler(target, "changed", on_changed)
+    if on_changed is not None:
+        self._set_custom_handler(target, "changed", on_changed)
     uuid = uuid4()
     self._send_data(obj, uuid)
     ret = self._wait_until(uuid)
@@ -96,7 +97,8 @@ def set_custom_checkbox(
     set_custom_control.target = str(target)
     obj = server_pb2.ServerCommand()
     obj.set_custom_control.CopyFrom(set_custom_control)
-    self._set_custom_handler(target, "changed", on_changed)
+    if on_changed is not None:
+        self._set_custom_handler(target, "changed", on_changed)
     uuid = uuid4()
     self._send_data(obj, uuid)
     ret = self._wait_until(uuid)
@@ -138,7 +140,8 @@ def set_custom_textbox(
     set_custom_control.target = str(target)
     obj = server_pb2.ServerCommand()
     obj.set_custom_control.CopyFrom(set_custom_control)
-    self._set_custom_handler(target, "changed", on_changed)
+    if on_changed is not None:
+        self._set_custom_handler(target, "changed", on_changed)
     uuid = uuid4()
     self._send_data(obj, uuid)
     ret = self._wait_until(uuid)
@@ -185,7 +188,8 @@ def set_custom_selectbox(
     set_custom_control.target = str(target)
     obj = server_pb2.ServerCommand()
     obj.set_custom_control.CopyFrom(set_custom_control)
-    self._set_custom_handler(target, "changed", on_changed)
+    if on_changed is not None:
+        self._set_custom_handler(target, "changed", on_changed)
     uuid = uuid4()
     self._send_data(obj, uuid)
     ret = self._wait_until(uuid)
@@ -222,7 +226,8 @@ def set_custom_button(
     set_custom_control.target = str(target)
     obj = server_pb2.ServerCommand()
     obj.set_custom_control.CopyFrom(set_custom_control)
-    self._set_custom_handler(target, "changed", on_changed)
+    if on_changed is not None:
+        self._set_custom_handler(target, "changed", on_changed)
     uuid = uuid4()
     self._send_data(obj, uuid)
     ret = self._wait_until(uuid)
@@ -264,7 +269,8 @@ def set_custom_colorpicker(
     set_custom_control.target = str(target)
     obj = server_pb2.ServerCommand()
     obj.set_custom_control.CopyFrom(set_custom_control)
-    self._set_custom_handler(target, "changed", on_changed)
+    if on_changed is not None:
+        self._set_custom_handler(target, "changed", on_changed)
     uuid = uuid4()
     self._send_data(obj, uuid)
     ret = self._wait_until(uuid)


### PR DESCRIPTION
**修正・解決されるissue**
Fix #70

**目的**
`set_custom_*`系メソッドが`on_change`のチェックをしておらず、引数に何も渡さないと`None`をセットしてしまっていた。

**変更点**
`on_change`が`None`の場合はハンドラの登録を行わないようにした。
ハンドラを消去する方法がなくなってしまったので、何もしない関数を渡してやるなどする必要がある。

**確認手順**

```python3
b = viewer.add_custom_button(name="test", on_change=f)
def f():
    viewer.set_custom_button(name="changed")
    print("test") # 複数回押せる
```
