### PR TITLE
Poetryのインストーラを更新

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,8 +46,8 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
 
 ENV PATH "$PATH:/home/vscode/local/python-3.8.7/bin"
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
-ENV PATH "$PATH:/home/vscode/.poetry/bin"
+ENV PATH "$PATH:/home/vscode/.local/bin"
 
 RUN poetry config virtualenvs.in-project true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       before_install:
         - curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
         - unzip protoc-3.15.6-linux-x86_64.zip && sudo cp ./bin/protoc /usr/local/bin/. && sudo chmod +x /usr/local/bin/protoc
-        - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        - curl -sSL https://install.python-poetry.org | python3 -
         - export PATH="$PATH:$HOME/.poetry/bin"
       install:
         - |-


### PR DESCRIPTION
**目的**
```bash
$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
Retrieving Poetry metadata

This installer is deprecated, and scheduled for removal from the Poetry repository on or after January 1, 2023.
See https://github.com/python-poetry/poetry/issues/6377 for details.

You should migrate to https://install.python-poetry.org instead, which supports all versions of Poetry, and allows for `self update` of versions 1.1.7 or newer.
Instructions are available at https://python-poetry.org/docs/#installation.

Without an explicit version, this installer will attempt to install the latest version of Poetry.
This installer cannot install Poetry 1.2.0a1 or newer (and installs will be unable to `self update` to 1.2.0a1 or newer).

To continue to use this deprecated installer, you must specify an explicit version with --version <version> or POETRY_VERSION=<version>.
Alternatively, if you wish to force this deprecated installer to use the latest installable release, set GET_POETRY_IGNORE_DEPRECATION=1.

Version 1.2.0 is not supported by this installer! Please specify a version prior to 1.2.0a1 to continue!
```

**変更点**
poetryのインストール手順を`https://install.python-poetry.org`を使ったものに変更
