### PR TITLE
Fix #75: スクリプトのファイル名にハッシュを追加

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   devtool: 'source-map',
   entry: './src/index.ts',
   output: {
-    filename: 'bundle.js',
+    filename: 'bundle-[hash].js',
     path: `${outputpath}`,
     clean: true
   },
@@ -42,7 +42,9 @@ module.exports = {
     watchContentBase: true
   },
   plugins: [
-    new HtmlWebpackPlugin(),
+    new HtmlWebpackPlugin({
+      title: 'cumo'
+    }),
     new MiniCssExtractPlugin()
   ]
 };


### PR DESCRIPTION
**修正・解決されるissue**
Fix #75

**目的**
ライブラリの更新後も更新前のスクリプトがキャッシュされていると正常に動作しないことがあった。

**変更点**
生成する`.js`ファイルのファイル名にハッシュを追加。ファイル名が異なるため、スクリプトの内容が変化するとブラウザはキャッシュを使わずに最新のスクリプトを取得してくれる。

**確認手順**
埋め込まれている`.js`ファイルにハッシュが含まれている。
