### PR TITLE
Resolve #80: バージョン指定を緩和

### DIFF
--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -24,11 +24,11 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.9"
-protobuf = "^3.15.6"
-websockets = "^8.1"
-numpy = "^1.20.2"
-Pillow = "^9.0.1"
+python = "^3.7"
+protobuf = "^3"
+websockets = "^8"
+numpy = "^1"
+Pillow = "^9"
 python-lzf = "^0.2.4"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
**修正・解決されるissue**
resolve #80

**目的**
バージョン指定が不必要に厳しく、利用の妨げになっていた。

**変更点**
バージョン指定を緩和。pythonは3.7以降でメジャーバージョンが3なら利用可能に。またライブラリのバージョン指定も緩くした。
