### PR TITLE
画像を3D空間上に置く機能を実装

### DIFF
--- a/lib/cumo/pointcloudviewer.py
+++ b/lib/cumo/pointcloudviewer.py
@@ -69,6 +69,7 @@ class PointCloudViewer:
         send_pointcloud,
         send_pointcloud_pcd,
         send_mesh,
+        send_image,
     )
     from cumo._internal.members.utils import (
         wait_forever,

--- a/protobuf/server.proto
+++ b/protobuf/server.proto
@@ -93,6 +93,7 @@ message AddObject {
         PointCloud point_cloud = 2;
         Overlay overlay = 3;
         Mesh mesh = 4;
+        Image image = 5;
     }
     message LineSet {
         repeated VecXYZf points = 1;
@@ -127,6 +128,13 @@ message AddObject {
         repeated int32 vertex_b_index = 3;
         repeated int32 vertex_c_index = 4;
         repeated VecRGBf colors = 5;
+    }
+    message Image {
+        bool double_side = 1;
+        VecXYZf upper_left = 2;
+        VecXYZf lower_left = 3;
+        VecXYZf lower_right = 4;
+        bytes data = 5;
     }
 }
 


### PR DESCRIPTION
**修正・解決されるissue**
no-issue

**目的**

> 3D空間上に画像を平面オブジェクトとして貼る機能があると便利かも？
> 例えばLIDAR点群の下に地図を表示する、みたいな用途。
> とりあえずはParaViewで点群と画像を同時に表示させて代用しました。

**変更点**
新しく画像を送れるようにコマンドを追加した。

**確認手順**
```python
with open("test.png", "bw") as f:
    viewer.send_image(f.read(), (0,1,0), (0,0,0), (0,0,1), double_side=True)
```
