### PR TITLE
Fix #89: 画像が間違った位置に描画されている問題を修正

### DIFF
--- a/client/src/websocket/handler/add_object.ts
+++ b/client/src/websocket/handler/add_object.ts
@@ -253,15 +253,15 @@ function handleImage (
     ];
 
     const indices: number[] = [
-      0, 2, 1,
-      2, 3, 1
+      1, 2, 0,
+      1, 3, 2
     ];
 
     const uvs: number[] = [
-      0, 1,
-      1, 1,
       0, 0,
-      1, 0
+      1, 0,
+      0, 1,
+      1, 1
     ];
 
     const geometry = new THREE.BufferGeometry();


### PR DESCRIPTION
**修正・解決されるissue**
Fix #89

**確認手順**
```python
with open("image.png", "br") as f:
    viewer.send_image(f.read(), (1,0,0), (0,0,0), (0,1,0), double_side=True)
```
