### PR TITLE
カメラの"上"を固定する機能を追加

### DIFF
--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -159,7 +159,10 @@ export class CustomCameraControls extends THREE.EventDispatcher {
       quaternion.setFromAxisAngle(axis, angle);
 
       this.eye.applyQuaternion(quaternion);
-      this.object.up.applyQuaternion(quaternion);
+
+      if (!this.noRoll) {
+        this.object.up.applyQuaternion(quaternion);
+      }
 
       this.movePrev.copy(this.moveCurr);
     }

--- a/client/src/websocket/handler/set_camera.ts
+++ b/client/src/websocket/handler/set_camera.ts
@@ -25,6 +25,9 @@ export function handleSetCamera (websocket: WebSocket, commandID: string, viewer
     case cameraCase.ROLL:
       setCameraRoll(websocket, commandID, viewer, camera.getRoll());
       break;
+    case cameraCase.ROLL_LOCK:
+      setCameraRollLock(websocket, commandID, viewer, camera.getRollLock());
+      break;
     default:
       sendFailure(websocket, commandID, 'message has not any camera parameters');
       break;
@@ -102,5 +105,10 @@ function setCameraRoll (websocket: WebSocket, commandID: string, viewer: PointCl
 
   viewer.controls.setRoll(angle, up);
   viewer.controls.update();
+  sendSuccess(websocket, commandID, 'success');
+}
+
+function setCameraRollLock (websocket: WebSocket, commandID: string, viewer: PointCloudViewer, locked: boolean) {
+  viewer.controls.noRoll = locked;
   sendSuccess(websocket, commandID, 'success');
 }

--- a/lib/cumo/_internal/members/camera.py
+++ b/lib/cumo/_internal/members/camera.py
@@ -153,3 +153,24 @@ def set_camera_roll(
     ret = self._wait_until(uuid)
     if ret.result.HasField("failure"):
         raise RuntimeError(ret.result.failure)
+
+
+def set_camera_roll_lock(
+    self: PointCloudViewer,
+    enable: bool,
+):
+    """カメラのロールを固定し、画面の上側が常に同じ方向を向くようにする機能を有効化、または無効化する。
+
+    Args:
+        enable (bool): Trueにセットすることでカメラの"上"が固定され、それが変更されるようなマウス操作が無効化される。
+    """
+    camera = server_pb2.SetCamera()
+    camera.roll_lock = enable
+
+    obj = server_pb2.ServerCommand()
+    obj.set_camera.CopyFrom(camera)
+    uuid = uuid4()
+    self._send_data(obj, uuid)
+    ret = self._wait_until(uuid)
+    if ret.result.HasField("failure"):
+        raise RuntimeError(ret.result.failure)

--- a/lib/cumo/pointcloudviewer.py
+++ b/lib/cumo/pointcloudviewer.py
@@ -49,6 +49,7 @@ class PointCloudViewer:
         set_orthographic_camera,
         set_perspective_camera,
         set_camera_roll,
+        set_camera_roll_lock,
     )
     from cumo._internal.members.custom_control import (
         add_custom_button,

--- a/protobuf/server.proto
+++ b/protobuf/server.proto
@@ -85,6 +85,7 @@ message SetCamera {
         VecXYZf position = 3;
         VecXYZf target = 4;
         Roll roll = 5;
+        bool roll_lock = 6;
     }
     message Roll {
         float angle = 1;


### PR DESCRIPTION
**修正・解決されるissue**
resolve #16

**目的**
マウス操作によってカメラのロールが変化するのは、地面が存在するような場面では都合が悪い。
そのため、そのようなマウス操作を無効化するモードを追加し、Python側から設定できるようにした。

**確認手順**
以下のようにすると画面の上側が(0,0,1)を向いた状態で固定され、カメラを上下左右に動かした後視線をもとに戻してもロールが変化しなくなっている。

```python
viewer.set_camera_roll(0,0,0,1)
viewer.set_camera_roll_lock(True)
```
