### PR TITLE
クライアント停止機能を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,6 @@
 			},
 		},
 		"terminal.integrated.defaultProfile.linux": "bash",
-		"python.formatting.autopep8Path": "/workspaces/pointcloud-viewer/lib/.venv/bin/autopep8",
 		"python.pythonPath": "/home/vscode/local/python-3.8.7/bin/python",
 		"editor.tabSize": 2,
 		"[typescript]": {

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ mv ./lib/cumo/protobuf ./lib/cumo/_internal/
 touch ./lib/cumo/_internal/protobuf/__init__.py
 
 cd ${WORKDIR}/client
+yarn lint:eslint
 yarn build
 
 cd ${WORKDIR}
@@ -39,4 +40,7 @@ cp README.md lib/
 
 cd ${WORKDIR}/lib
 poetry install
+poetry run autopep8 --diff --recursive --exit-code --exclude=protobuf,pypcd,docs .
+poetry run flake8 --exclude cumo/_vendor,cumo/_internal/protobuf,cumo/__init__.py cumo
+poetry run pylint --jobs=0 cumo
 poetry build

--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -245,6 +245,7 @@ export class CustomCameraControls extends THREE.EventDispatcher {
   }
 
   update = () => {
+    if (!this.enabled) return;
     this.eye.subVectors(this.object.position, this.target);
     const oldQuaternion = new THREE.Quaternion();
     oldQuaternion.copy(this.object.quaternion);

--- a/client/src/index.d.ts
+++ b/client/src/index.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}

--- a/client/src/spinner.svg
+++ b/client/src/spinner.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="100" width="100" viewBox="0 0 100 100">
+<circle cx="50" cy="50" r="40" stroke-width="8" />
+</svg>

--- a/client/src/spinner.ts
+++ b/client/src/spinner.ts
@@ -1,0 +1,21 @@
+/// <reference path="index.d.ts" />
+import SPINNER_SVG from './spinner.svg';
+
+export class Spinner {
+  __elem: HTMLDivElement
+  constructor (private container: HTMLElement) {
+    this.__elem = document.createElement('div');
+    this.__elem.innerHTML = SPINNER_SVG;
+    this.__elem.className = 'cumo-spinner';
+    this.__elem.style.display = 'none';
+    this.container.appendChild(this.__elem);
+  }
+
+  show () {
+    this.__elem.style.display = 'initial';
+  }
+
+  hide () {
+    this.__elem.style.display = 'none';
+  }
+}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -16,3 +16,28 @@ body {
 .cr.function .property-name {
     width: 100%;
 }
+
+@keyframes spinner {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.cumo-spinner {
+    position: fixed;
+    top: calc(50% - 20px);
+    left: calc(50% - 20px);
+}
+
+.cumo-spinner circle {
+    fill: none;
+    stroke: white;
+    stroke-width: 5;
+    stroke-linecap: round;
+    stroke-dasharray: 2.5 calc(3.14 * 40 * 2 - 2.5);
+    transform-origin: 50px 50px 0;
+    animation: spinner 1s linear infinite;
+}

--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -6,8 +6,10 @@ import { Overlay } from './overlay';
 import { Canvas2D } from './canvas2d';
 import { Lineset } from './lineset';
 import { CustomCameraControls } from './camera_control';
+import { Spinner } from './spinner';
 
 export class PointCloudViewer {
+    enabled: boolean = true;
     renderer: THREE.WebGLRenderer;
     scene: THREE.Scene;
 
@@ -15,6 +17,7 @@ export class PointCloudViewer {
     overlayContainer: HTMLElement
 
     canvas2d: Canvas2D
+    spinner: Spinner
 
     linesets: Lineset[] = [];
 
@@ -156,6 +159,8 @@ export class PointCloudViewer {
         this.render();
       };
       animate();
+
+      this.spinner = new Spinner(container);
     }
 
     get getdiv () {
@@ -163,6 +168,7 @@ export class PointCloudViewer {
     }
 
     render (): void {
+      if (!this.enabled) return;
       const camera = this.config.camera.usePerspective ? this.perspectiveCamera : this.orthographicCamera;
       this.renderer.render(
         this.scene,

--- a/client/src/websocket/handler/set_enable.ts
+++ b/client/src/websocket/handler/set_enable.ts
@@ -1,0 +1,15 @@
+import { PointCloudViewer } from '../../viewer';
+import { sendSuccess } from '../client_command';
+
+export function handleSetEnable (websocket: WebSocket, commandID: string, viewer: PointCloudViewer, enabled: boolean): void {
+  viewer.enabled = enabled;
+  viewer.controls.enabled = enabled;
+  if (enabled) {
+    viewer.spinner.hide();
+  } else {
+    viewer.controls.update();
+    viewer.render();
+    viewer.spinner.show();
+  }
+  sendSuccess(websocket, commandID, 'success');
+}

--- a/client/src/websocket/websocket.ts
+++ b/client/src/websocket/websocket.ts
@@ -11,6 +11,7 @@ import { handleRemoveControl } from './handler/remove_control';
 import { handleRemoveObject } from './handler/remove_object';
 import { handleSetCamera } from './handler/set_camera';
 import { handleSetControl } from './handler/set_control';
+import { handleSetEnable } from './handler/set_enable';
 import { handleSetKeyEvent } from './handler/set_key_event';
 
 export function connectWebSocket (viewer: PointCloudViewer, url: string) {
@@ -58,6 +59,9 @@ function handleProtobuf (websocket: WebSocket, viewer: PointCloudViewer, message
         break;
       case commandCase.SET_CUSTOM_CONTROL:
         handleSetControl(websocket, commandID, viewer, message.getSetCustomControl());
+        break;
+      case commandCase.SET_ENABLE:
+        handleSetEnable(websocket, commandID, viewer, message.getSetEnable());
         break;
       default:
         sendFailure(websocket, commandID, 'message has not any command');

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -29,6 +29,10 @@ module.exports = {
         test: /\.css/,
         use: [MiniCssExtractPlugin.loader, 'css-loader'],
         exclude: '/node_modules/'
+      },
+      {
+        test: /\.(svg)$/i,
+        type: 'asset/source'
       }
     ]
   },

--- a/lib/cumo/_internal/members/set_enable.py
+++ b/lib/cumo/_internal/members/set_enable.py
@@ -1,0 +1,35 @@
+from __future__ import annotations  # Postponed Evaluation of Annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from cumo._internal.protobuf import server_pb2
+
+if TYPE_CHECKING:
+    from cumo import PointCloudViewer
+
+
+def stop_render(self: PointCloudViewer):
+    """クライアントの描画を停止させる。また、カメラコントロールも無効化される。
+    """
+    obj = server_pb2.ServerCommand()
+    obj.set_enable = False
+
+    uuid = uuid4()
+    self._send_data(obj, uuid)
+    ret = self._wait_until(uuid)
+    if ret.result.HasField("failure"):
+        raise RuntimeError(ret.result.failure)
+
+
+def resume_render(self: PointCloudViewer):
+    """クライアントの描画を再開させる。カメラもマウスによって操作できるようになる。
+    """
+    obj = server_pb2.ServerCommand()
+    obj.set_enable = True
+
+    uuid = uuid4()
+    self._send_data(obj, uuid)
+    ret = self._wait_until(uuid)
+    if ret.result.HasField("failure"):
+        raise RuntimeError(ret.result.failure)

--- a/lib/cumo/pointcloudviewer.py
+++ b/lib/cumo/pointcloudviewer.py
@@ -105,3 +105,7 @@ class PointCloudViewer:
         set_custom_checkbox,
         set_custom_button,
     )
+    from cumo._internal.members.set_enable import (
+        stop_render,
+        resume_render,
+    )

--- a/protobuf/server.proto
+++ b/protobuf/server.proto
@@ -13,6 +13,7 @@ message ServerCommand {
         RemoveObject remove_object = 8;
         RemoveCustomControl remove_custom_control = 9;
         SetCustomControl set_custom_control = 10;
+        bool set_enable = 11;
     }
 }
 


### PR DESCRIPTION
**修正・解決されるissue**
resolve #35

**目的**
クライアントの描画と操作に対する反応を停止/再開させる機能を追加

**変更点**
`viewer.stop_render`、`viewer.resume_render`を追加。

**確認手順**
```python
    viewer.stop_render()

    for i in range(1000):
        points = numpy.array([
            [numpy.random.uniform(-1.0,1.0), numpy.random.uniform(-1.0,1.0), numpy.random.uniform(-1.0,1.0)],
            [numpy.random.uniform(-1.0,1.0), numpy.random.uniform(-1.0,1.0), numpy.random.uniform(-1.0,1.0)],
            [numpy.random.uniform(-1.0,1.0), numpy.random.uniform(-1.0,1.0), numpy.random.uniform(-1.0,1.0)],
        ]).astype("float32")
        colors = numpy.array([[numpy.random.randint(0,255),numpy.random.randint(0,255),numpy.random.randint(0,255)]]).astype("uint8")
        triangles = numpy.array([[0,1,2]]).astype("uint32")

        viewer.send_mesh(points, triangles, colors)
    
    viewer.resume_render()
```
