### PR TITLE
Fix #110: オーバーレイの削除コードを復元

### DIFF
--- a/client/src/websocket/handler/remove_object.ts
+++ b/client/src/websocket/handler/remove_object.ts
@@ -46,6 +46,16 @@ function handleRemoveByUUID (websocket: WebSocket, commandID: string, viewer: Po
     return;
   }
 
+  for (let i = 0; i < viewer.overlays.length; i++) {
+    const overlay = viewer.overlays[i];
+    if (overlay.uuid === uuid.toUpperCase()) {
+      overlay.dispose();
+      viewer.overlays.splice(i, 1);
+      sendSuccess(websocket, commandID, 'success');
+      return;
+    }
+  }
+
   for (let i = 0; i < viewer.linesets.length; i++) {
     const lineset = viewer.linesets[i];
     if (lineset.UUID === normalizedUUID) {


### PR DESCRIPTION
**修正・解決されるissue**
Fix #110

**目的**
オーバーレイをremove_objectで削除しようとすると失敗していた問題を解決

**変更点**
その処理を行うコードが単純に消滅してたので復活させた

**確認手順**
issue参照
