### PR TITLE
fix #113: ズーム補正を修正

### DIFF
--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -30,8 +30,8 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
   panSpeed: number = 0.3;
   rollSpeed: number = 1.0;
 
-  minDistance: number = 0.1;
-  maxDistance: number = Infinity
+  minDistance: number = 0.001;
+  maxDistance: number = Number.MAX_SAFE_INTEGER;
 
   frustum: number | undefined;
   zoom: number = 1.0;
@@ -211,11 +211,15 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
     if (this.noZoom && this.noPan) return;
     if (this.camera === null) return;
     if (this.eye.lengthSquared() > this.maxDistance * this.maxDistance) {
-      this.target.subtractToRef(this.eye.clone().normalize().scale(this.maxDistance), this.camera.position);
+      this.eye.normalize().scaleInPlace(this.maxDistance);
+      this.target.subtractToRef(this.eye, this.camera.position);
+      this.zoom = this.maxDistance;
       this.zoomStart.copyFrom(this.zoomEnd);
     }
     if (this.eye.lengthSquared() < this.minDistance * this.minDistance) {
-      this.target.subtractToRef(this.eye.clone().normalize().scale(this.maxDistance), this.camera.position);
+      this.eye.normalize().scaleInPlace(this.minDistance);
+      this.target.subtractToRef(this.eye, this.camera.position);
+      this.zoom = this.minDistance;
       this.zoomStart.copyFrom(this.zoomEnd);
     }
   }


### PR DESCRIPTION
**修正・解決されるissue**
Fix #113

**目的**
issue参照

**変更点**
`maxDIstance`が無限大になっていたが、それでは役に立たないのでもう少し小さな値に修正。
また、ターゲットまでの距離が`minDistance`を下回ったら`minDistance`にするはずが、`maxDistance`になっていたので修正。
