### PR TITLE
Linesetの描画を厳密化

### DIFF
--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -169,8 +169,11 @@ export class PointCloudViewer {
       this.overlays[i].render(this.canvas, this.scene);
     }
     this.canvas2d.ctx.clearRect(0, 0, this.canvas2d.domElement.width, this.canvas2d.domElement.height);
+
+    const mat = this.camera.getTransformationMatrix();
+
     for (let i = 0; i < this.linesets.length; i++) {
-      this.linesets[i].render(this.canvas2d, this.scene);
+      this.linesets[i].render(this.canvas2d, this.scene, mat);
     }
   }
 


### PR DESCRIPTION
**修正・解決されるissue**
Fix #68

**目的**

![スクリーンショット 2023-08-07 202814](https://github.com/kurusugawa-computer/cumo/assets/8435623/23f17dd3-0431-4215-83c3-aed2e2849e24)

**変更点**
画面外にある線分は描画しないようにした。
一部だけ視界に入っている線分は視界に入っている部分だけ描画するようにした。

![スクリーンショット 2023-08-07 202915](https://github.com/kurusugawa-computer/cumo/assets/8435623/1ffba6e7-2d2d-48fd-a505-7d1572f71097)

**確認手順**
```python3
import numpy as np
from cumo import PointCloudViewer
import random

viewer = PointCloudViewer()
viewer.start()

viewer.stop_render()

viewer.remove_all_custom_controls()
viewer.remove_all_objects()

for n, color in [
    (1, [255, 0, 0]),
    (10, [0, 255, 0]),
    (100, [0, 0, 255]),
]:
    # 立方体を描画する

    xyz = np.array([
        [-n, -n, -n],
        [+n, -n, -n],
        [-n, +n, -n],
        [+n, +n, -n],
        [-n, -n, +n],
        [+n, -n, +n],
        [-n, +n, +n],
        [+n, +n, +n],
    ], dtype=np.float32)

    from_to = np.array([
        [0, 1],
        [2, 3],
        [4, 5],
        [6, 7],
        [0, 2],
        [1, 3],
        [4, 6],
        [5, 7],
        [0, 4],
        [1, 5],
        [2, 6],
        [3, 7],
    ], dtype=np.uint32)

    rgb = np.full((len(from_to), 3), color, dtype=np.uint8)

    viewer.send_lineset(
        xyz=xyz,
        from_to=from_to,
        rgb=rgb,
    )

viewer.set_camera_position(2.7, 3.0, 3.3)

viewer.resume_render()

viewer.wait_forever()

```
