### PR TITLE
Resolve #15: コントロールパネル自動拡張機能を追加

### DIFF
--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -8,6 +8,7 @@ import { Spinner } from './spinner';
 import * as BABYLON from '@babylonjs/core';
 import '@babylonjs/core/Legacy/legacy';
 import { CustomCameraInput } from './camera_control';
+import { adjustControlPanelWidthFromContent } from './websocket/handler/util';
 
 export class PointCloudViewer {
   enabled: boolean = true;
@@ -132,6 +133,8 @@ export class PointCloudViewer {
     guiControl.add(this.config.controls, 'rotateSpeed', 0, 10, 0.1).onChange(() => { this.cameraInput.rotateSpeed = this.config.controls.rotateSpeed; });
     guiControl.add(this.config.controls, 'zoomSpeed', 0, 10, 0.1).onChange(() => { this.cameraInput.zoomSpeed = this.config.controls.zoomSpeed; });
     guiControl.add(this.config.controls, 'panSpeed', 0, 10, 0.1).onChange(() => { this.cameraInput.panSpeed = this.config.controls.panSpeed; });
+
+    adjustControlPanelWidthFromContent(this.gui);
 
     // [UUID]: folderName な map を初期化
     this.folderUUIDmap = {};

--- a/client/src/websocket/handler/add_control.ts
+++ b/client/src/websocket/handler/add_control.ts
@@ -1,7 +1,7 @@
 import * as PB from '../../protobuf/server';
 import { sendSuccess, sendFailure, sendControlChanged } from '../client_command';
 import { PointCloudViewer } from '../../viewer';
-import { findFolderByUUID } from './util';
+import { adjustControlPanelWidthFromContent, findFolderByUUID } from './util';
 
 export function handleAddControl (
   websocket: WebSocket,
@@ -185,5 +185,6 @@ export function handleAddControl (
       sendFailure(websocket, commandID, 'invalid command');
       return;
   }
+  adjustControlPanelWidthFromContent(viewer.gui);
   sendSuccess(websocket, commandID, commandID);
 }

--- a/client/src/websocket/handler/remove_control.ts
+++ b/client/src/websocket/handler/remove_control.ts
@@ -1,6 +1,7 @@
 import * as PB from '../../protobuf/server';
 import { sendSuccess, sendFailure } from '../client_command';
 import { PointCloudViewer } from '../../viewer';
+import { adjustControlPanelWidthFromContent } from './util';
 
 export function handleRemoveControl (
   websocket: WebSocket,
@@ -22,6 +23,7 @@ export function handleRemoveControl (
     default:
       break;
   }
+  adjustControlPanelWidthFromContent(viewer.gui);
 }
 
 function handleRemoveAll (websocket: WebSocket, commandID: string, viewer: PointCloudViewer) {

--- a/client/src/websocket/handler/util.ts
+++ b/client/src/websocket/handler/util.ts
@@ -79,3 +79,28 @@ export function findGUIController (
 
   return null;
 }
+
+// ラベルが隠れないように画面の半分までGUIの横幅を広げる
+export function adjustControlPanelWidthFromContent (gui: GUI) {
+  const labels = document.querySelectorAll<HTMLDivElement>('.dg .property-name').values();
+  let maxWidth = 0;
+  const ctx = document.createElement('canvas').getContext('2d');
+  if (ctx === null) return;
+  for (const l of labels) {
+    ctx.font = window.getComputedStyle(l).font;
+    const m = ctx.measureText(l.innerText);
+    const w = m.actualBoundingBoxLeft + m.actualBoundingBoxRight;
+    maxWidth = Math.max(w, maxWidth);
+  }
+  const mainWidth = Math.ceil(maxWidth / 0.4);
+  const title = document.querySelector<HTMLLIElement>('.dg li.title');
+  const padding = (() => {
+    if (title === null) return 20;
+    const s = window.getComputedStyle(title);
+    // computed length is always in the form '*px'
+    return Number.parseFloat(s.paddingLeft) + Number.parseFloat(s.paddingRight);
+  })();
+  // +1 for dat.gui bugs
+  // sometimes the actual width will be 1px less than the passed value
+  gui.width = Math.max(gui.width, Math.min(mainWidth + padding + 1, window.innerWidth / 2));
+}

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 readme = "README.md"
 name = "cumo"
-version = "0.29.1"
+version = "0.30.0"
 description = "Webブラウザ上に点群を描画する python ライブラリ"
 authors = ["Kurusugawa Computer"]
 license = "BSD"


### PR DESCRIPTION
**修正・解決されるissue**
Resolve #15

**目的**
コントロールパネルで長めのラベルを使うと後半が展開しないと読めなくなっていた。

**変更点**
要素を追加したときにコントロールパネルが自動で画面の半分まで広がるようになった。
すでに十分大きくなっているときは変更しない。

**確認手順**

![スクリーンショット 2023-08-27 203740](https://github.com/kurusugawa-computer/cumo/assets/8435623/a43dc054-dbcd-4e04-96b7-903f6155661a)
![スクリーンショット 2023-08-27 203827](https://github.com/kurusugawa-computer/cumo/assets/8435623/c0201d35-c051-4ec2-95ba-23478d557943)
