### PR TITLE
描画距離の設定値が極端すぎたので修正

### DIFF
--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -69,8 +69,8 @@ export class PointCloudViewer {
   }();
 
   constructor (private container: HTMLDivElement) {
-    const cameraNear = 0.00001;
-    const cameraFar = 100000;
+    const cameraNear = 0.1;
+    const cameraFar = 10000;
 
     this.canvas = document.createElement('canvas');
 

--- a/client/src/websocket/handler/add_object.ts
+++ b/client/src/websocket/handler/add_object.ts
@@ -274,7 +274,6 @@ function handlePointCloud (
   mat.pointSize = pbPointcloud.pointSize;
 
   const mesh = new BABYLON.Mesh(commandID, viewer.scene);
-  mesh.renderingGroupId = 1;
   vertexData.applyToMesh(mesh, true);
   mesh.material = mat;
 


### PR DESCRIPTION
これによって、デプス計算の誤差が小さくなり、点群やメッシュのオクルージョンが正しく行われるようになる。

**修正・解決されるissue**
Fix #125
