### PR TITLE
意図せず左手座標系になっていたのを修正

### DIFF
--- a/client/src/viewer.ts
+++ b/client/src/viewer.ts
@@ -85,6 +85,7 @@ export class PointCloudViewer {
     this.scene = new BABYLON.Scene(this.engine);
     this.scene.clearColor = new BABYLON.Color4(0, 0, 0);
     this.scene.lightsEnabled = false;
+    this.scene.useRightHandedSystem = true;
 
     this.camera = new BABYLON.FreeCamera('camera', new BABYLON.Vector3(-1, -1, -1), this.scene);
     this.camera.fov = (this.config.camera.perspective.fov / 180) * Math.PI;


### PR DESCRIPTION
**修正・解決されるissue**
no-issue

**目的**
three.jsは右手座標系だが、babylon.jsは左手座標系である。
ライブラリを変更したときに左右が反転していたが、いままで気づいていなかった。

**変更点**
`useRightHandedSystem`を設定して右手座標系を使うようにした。

**確認手順**
サンプルを起動する。
ちょっとわかりにくいが座標系が右手座標系になっている。
