### PR TITLE
右手座標系に合わせてカメラコントロールのパン機能を修正

### DIFF
--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -200,8 +200,12 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
 
     if (mouseChange.lengthSquared()) {
       mouseChange.scaleInPlace(this.eye.length() * this.panSpeed);
+
+      // screen coordinate: positive y is up and positive x is right
+      // camera coordinate: if axis A is pointing up and axis B is pointing forward, then the other axis is pointing left (right handed coordinate system)
       const pan = this.eye.cross(this.camera.upVector).normalize()
-        .scaleInPlace(mouseChange.x);
+        .scaleInPlace(-mouseChange.x);
+
       pan.addInPlace(this.camera.upVector.scale(mouseChange.y));
 
       this.target.addInPlace(pan);


### PR DESCRIPTION
**修正・解決されるissue**
no-issue

**目的**
座標系が右手座標系になったことにより、上と前の外積が左を指すようになり、パンの左右方向が反転していた。

**変更点**
符号を変えて向きを修正した。

**確認手順**
