### PR TITLE
パン時にカメラ上方向ベクトルを計算する

### DIFF
--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -203,9 +203,9 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
 
       // calculate true up vector
       const eye = this.eye.clone();
-      const camUp = this.camera.upVector.clone();
-      const upProj = eye.scale(BABYLON.Vector3.Dot(eye, camUp) / eye.lengthSquared());
-      const upVector = camUp.subtract(upProj).normalize();
+      const cameraUp = this.camera.upVector.clone();
+      const cameraUpProjection = eye.scale(BABYLON.Vector3.Dot(eye, cameraUp) / eye.lengthSquared());
+      const upVector = cameraUp.subtract(cameraUpProjection).normalize();
 
       // screen coordinate: positive y is up and positive x is right
       // camera coordinate: if axis A is pointing up and axis B is pointing forward, then the other axis is pointing left (right handed coordinate system)

--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -201,12 +201,18 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
     if (mouseChange.lengthSquared()) {
       mouseChange.scaleInPlace(this.eye.length() * this.panSpeed);
 
+      // calculate true up vector
+      const eye = this.eye.clone();
+      const camUp = this.camera.upVector.clone();
+      const upProj = eye.scale(BABYLON.Vector3.Dot(eye, camUp) / eye.lengthSquared());
+      const upVector = camUp.subtract(upProj).normalize();
+
       // screen coordinate: positive y is up and positive x is right
       // camera coordinate: if axis A is pointing up and axis B is pointing forward, then the other axis is pointing left (right handed coordinate system)
-      const pan = this.eye.cross(this.camera.upVector).normalize()
+      const pan = this.eye.cross(upVector).normalize()
         .scaleInPlace(-mouseChange.x);
 
-      pan.addInPlace(this.camera.upVector.scale(mouseChange.y));
+      pan.addInPlace(upVector.scale(mouseChange.y));
 
       this.target.addInPlace(pan);
       this.panStart.copyFrom(this.panEnd);


### PR DESCRIPTION
**修正・解決されるissue**
Fix #14

**目的**
カメラの状態によって、平行移動（パン）が非常に遅くなる問題があった。
パン時のベクトル計算にカメラに設定された上ベクトルを使用しているが、固定モード時にはこのベクトルが正しく画面上の上方向を指さない場合があり、その場合にパンが正常に動かないことが要因と考えられる。

**変更点**
パン時に視線ベクトルとカメラ設定の上方ベクトルを利用して、正しい上ベクトルを計算する。

**確認手順**
ロール固定モードを使用してからカメラを真上を向かせ、その状態でパンニングが正常に動くことを確認する。

**備考**

**確認事項**
 - [x] 修正途中であればDraftになっていますか？
 - [x] タイトルはわかりやすいですか？(何をどうするを書いてください)
