### PR TITLE
fix #94: ロール固定モードの時に上下周りで横方向の回転速度が速すぎる

### DIFF
--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -145,40 +145,69 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
 
   private rotateCamera () {
     if (this.camera === null) return;
-    const moveDirection = new BABYLON.Vector3(
-      this.moveCurr.x - this.movePrev.x,
-      this.moveCurr.y - this.movePrev.y,
-      0
-    );
-    let angle = moveDirection.length();
-    if (angle) {
+    // roll-rock mode
+    if (this.noRoll) {
       this.target.subtractToRef(this.camera.position, this.eye);
-
       const eyeDirection = this.eye.clone();
-      eyeDirection.normalize();
-      const objectUpDirection = this.camera.upVector.clone();
-      objectUpDirection.normalize();
-      const objectSidewaysDirection = objectUpDirection.cross(eyeDirection);
-      objectSidewaysDirection.normalize();
 
-      objectUpDirection.scaleInPlace(this.moveCurr.y - this.movePrev.y);
-      objectSidewaysDirection.scaleInPlace(this.moveCurr.x - this.movePrev.x);
+      const moveSidewayDirection = new BABYLON.Vector3(
+        this.moveCurr.x - this.movePrev.x,
+        0,
+        0
+      );
+      let angle = moveSidewayDirection.length();
+      if (angle) {
+        const objectUpDirection = this.camera.upVector.clone();
+        objectUpDirection.normalize();
+        objectUpDirection.scaleInPlace(this.moveCurr.x - this.movePrev.x);
+        angle *= this.rotateSpeed;
+        const quaternion = BABYLON.Quaternion.RotationAxis(objectUpDirection, angle).normalize();
+        this.eye.applyRotationQuaternionInPlace(quaternion);
+      }
+      const moveUpDirection = new BABYLON.Vector3(
+        0,
+        this.moveCurr.y - this.movePrev.y,
+        0
+      );
+      angle = moveUpDirection.length();
+      if (angle) {
+        const objectSidewayDirection = this.camera.upVector.cross(eyeDirection);
+        objectSidewayDirection.normalize();
+        objectSidewayDirection.scaleInPlace(this.moveCurr.y - this.movePrev.y);
+        angle *= this.rotateSpeed;
+        const quaternion = BABYLON.Quaternion.RotationAxis(objectSidewayDirection, angle).normalize();
+        this.eye.applyRotationQuaternionInPlace(quaternion);
+      }
+    } else {
+      const moveDirection = new BABYLON.Vector3(
+        this.moveCurr.x - this.movePrev.x,
+        this.moveCurr.y - this.movePrev.y,
+        0
+      );
+      let angle = moveDirection.length();
+      if (angle) {
+        this.target.subtractToRef(this.camera.position, this.eye);
 
-      objectUpDirection.addToRef(objectSidewaysDirection, moveDirection);
-      const axis = moveDirection.cross(eyeDirection).normalize();
+        const eyeDirection = this.eye.clone();
+        eyeDirection.normalize();
+        const objectUpDirection = this.camera.upVector.clone();
+        objectUpDirection.normalize();
+        const objectSidewaysDirection = objectUpDirection.cross(eyeDirection);
+        objectSidewaysDirection.normalize();
+        objectUpDirection.scaleInPlace(this.moveCurr.y - this.movePrev.y);
+        objectSidewaysDirection.scaleInPlace(this.moveCurr.x - this.movePrev.x);
+        objectUpDirection.addToRef(objectSidewaysDirection, moveDirection);
+        const axis = moveDirection.cross(eyeDirection).normalize();
+        angle *= this.rotateSpeed;
+        const quaternion = BABYLON.Quaternion.RotationAxis(axis, angle).normalize();
 
-      angle *= this.rotateSpeed;
-      const quaternion = BABYLON.Quaternion.RotationAxis(axis, angle).normalize();
+        this.eye.applyRotationQuaternionInPlace(quaternion);
 
-      this.eye.applyRotationQuaternionInPlace(quaternion);
-
-      if (!this.noRoll) {
         this.camera.upVector = this.camera.upVector.normalizeToNew()
           .applyRotationQuaternion(quaternion).normalizeToNew();
       }
-
-      this.movePrev.copyFrom(this.moveCurr);
     }
+    this.movePrev.copyFrom(this.moveCurr);
   }
 
   private zoomCamera () {

--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -150,32 +150,20 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
       this.target.subtractToRef(this.camera.position, this.eye);
       const eyeDirection = this.eye.clone();
 
-      const moveSidewayDirection = new BABYLON.Vector3(
-        this.moveCurr.x - this.movePrev.x,
-        0,
-        0
-      );
-      let angle = moveSidewayDirection.length();
-      if (angle) {
+      let sidewayAngle = this.moveCurr.x - this.movePrev.x;
+      if (sidewayAngle) {
         const objectUpDirection = this.camera.upVector.clone();
         objectUpDirection.normalize();
-        objectUpDirection.scaleInPlace(this.moveCurr.x - this.movePrev.x);
-        angle *= this.rotateSpeed;
-        const quaternion = BABYLON.Quaternion.RotationAxis(objectUpDirection, angle).normalize();
+        sidewayAngle *= this.rotateSpeed;
+        const quaternion = BABYLON.Quaternion.RotationAxis(objectUpDirection, sidewayAngle).normalize();
         this.eye.applyRotationQuaternionInPlace(quaternion);
       }
-      const moveUpDirection = new BABYLON.Vector3(
-        0,
-        this.moveCurr.y - this.movePrev.y,
-        0
-      );
-      angle = moveUpDirection.length();
-      if (angle) {
+      let upAngle = this.moveCurr.y - this.movePrev.y;
+      if (upAngle) {
         const objectSidewayDirection = this.camera.upVector.cross(eyeDirection);
         objectSidewayDirection.normalize();
-        objectSidewayDirection.scaleInPlace(this.moveCurr.y - this.movePrev.y);
-        angle *= this.rotateSpeed;
-        const quaternion = BABYLON.Quaternion.RotationAxis(objectSidewayDirection, angle).normalize();
+        upAngle *= this.rotateSpeed;
+        const quaternion = BABYLON.Quaternion.RotationAxis(objectSidewayDirection, upAngle).normalize();
         this.eye.applyRotationQuaternionInPlace(quaternion);
       }
     } else {

--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -150,7 +150,7 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
       this.target.subtractToRef(this.camera.position, this.eye);
       const eyeDirection = this.eye.clone();
 
-      let sidewayAngle = this.moveCurr.x - this.movePrev.x;
+      let sidewayAngle = -(this.moveCurr.x - this.movePrev.x);
       if (sidewayAngle) {
         const objectUpDirection = this.camera.upVector.clone();
         objectUpDirection.normalize();


### PR DESCRIPTION
**修正・解決されるissue**
Fix [#94](https://github.com/kurusugawa-computer/cumo/issues/94)

**目的**
ロール固定モード時、上下を向くほど横方向の回転速度が速くなる現象が起きていた
上下の向きに関わらず回転速度を一定にしたい

**変更点**
ロール固定モード時は横方向と縦方向に分けて回転を行うように変更した。
これによって、ロール固定をしたままマウス移動量に対して自然な回転をすることができるようになった。

（変更前は、通常の回転をロール固定するために無理やり軌道を捻じ曲げた状態だったため、計算上の軌道の長さより実際の軌道の長さの方が短くなってしまい、回転の速度が速くなってしまっていた）

**確認手順**
ロール固定モードで起動したのち、上下方向に向く方向を変えながら横移動してみる
ロール固定モードで起動するには、`lib/cumo/__main.py`のmain関数末尾（32行目あたり）に以下の記述を追加する（issueの通り）
```
viewer.set_camera_roll(0,0,0,1)
viewer.set_camera_roll_lock(True)
```

