### PR TITLE
fix#137 ロール軸固定モードで極付近のマウス上下移動によりカメラが暴れる

### DIFF
--- a/client/src/camera_control.ts
+++ b/client/src/camera_control.ts
@@ -163,6 +163,16 @@ export class CustomCameraInput<TCamera extends BABYLON.TargetCamera> implements 
         const objectSidewayDirection = this.camera.upVector.cross(eyeDirection);
         objectSidewayDirection.normalize();
         upAngle *= this.rotateSpeed;
+        // avoid rolling
+        const negatedEyeDirection = eyeDirection.negate();
+        const normal = BABYLON.Vector3.Cross(this.camera.upVector, negatedEyeDirection).normalize();
+        const angleBetweenUpandEye = BABYLON.Vector3.GetAngleBetweenVectors(this.camera.upVector, negatedEyeDirection, normal);
+        const angleOffset = 0.00156;
+        if (upAngle >= 0) {
+          upAngle = Math.min(upAngle, Math.max(0, angleBetweenUpandEye - angleOffset));
+        } else {
+          upAngle = -Math.min(Math.abs(upAngle), Math.max(0, Math.PI - angleBetweenUpandEye - angleOffset));
+        }
         const quaternion = BABYLON.Quaternion.RotationAxis(objectSidewayDirection, upAngle).normalize();
         this.eye.applyRotationQuaternionInPlace(quaternion);
       }


### PR DESCRIPTION
**修正・解決されるissue**
Fix [#137](https://github.com/kurusugawa-computer/cumo/issues/137)

**目的**
ロール軸固定モード時、極付近のマウス上下移動時にカメラが暴れる問題を解決

**変更点**
上下移動に対して、極を飛び越えないような移動量の上限を計算して移動量に上限を設けた。
しかし、極ぴったりを基準にしてしまうとカメラが暴れるままだったため、offsetを設定して少しだけ余裕を持たせてある。offsetは二分探索を用いて問題の挙動が起きない中で限りなく小さいものを設定してあり、見かけ上はほぼ真上(真下)から点群を見られる。

