### PR TITLE
自動リリース

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,3 +54,5 @@ RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="$PATH:/home/vscode/.local/bin"
 
 RUN poetry config virtualenvs.in-project true
+
+RUN poetry self add "poetry-dynamic-versioning[plugin]"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -11,9 +11,11 @@ RUN apt-get update \
     && ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
     && echo 'Asia/Tokyo' >/etc/timezone
 
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    curl gnupg unzip git sudo\
+    curl gnupg unzip \
     make build-essential libssl-dev zlib1g-dev libbz2-dev bash-completion \
     libreadline-dev libsqlite3-dev llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev libusb-1.0-0 libgl1-mesa-dev \
@@ -31,10 +33,6 @@ ENV PROTOC_VERSION=24.2
 RUN curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
     && unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip && cp ./bin/protoc /usr/local/bin/. && chmod +x /usr/local/bin/protoc
 
-RUN groupadd --gid 1000 vscode \
-    && useradd --uid 1000 --gid 1000 -m vscode \
-    && echo vscode ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/vscode \
-    && chmod 0440 /etc/sudoers.d/vscode
 USER vscode
 
 ENV PYTHON_VERSION=3.8.7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  deploy:
+    name: Deploy to PyPI
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write # for gh-action-pypi-publish
+      contents: write # for action-gh-release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/Iron"
+      - name: Install yarn
+        run: npm install -g yarn
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "${HOME}/.local/bin" >> ${GITHUB_PATH}
+          ${HOME}/.local/bin/poetry config virtualenvs.in-project true
+      - name: Install protoc
+        env:
+          PROTOC_VERSION: "24.2"
+        run: |
+          curl -L -O https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip
+          cp ./bin/protoc /usr/local/bin/.
+          chmod +x /usr/local/bin/protoc
+      - name: Build
+        run: |
+          make build
+      # https://docs.github.com/ja/enterprise-cloud@latest/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Deploy to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: "lib/dist"
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: lib/dist/*
+          generate_release_notes: true

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 readme = "README.md"
 name = "cumo"
-version = "0.33.7"
+version = "0.0.0" # dynamic-versioningによりgitタグ名がバージョンになる
 description = "Webブラウザ上に点群を描画する python ライブラリ"
 authors = ["Kurusugawa Computer"]
 license = "BSD"
@@ -18,10 +18,7 @@ classifiers = [
 	"Topic :: Utilities",
 	"Operating System :: OS Independent",
 ]
-include = [
-    "cumo/public/*",
-    "cumo/_internal/protobuf/*",
-]
+include = ["cumo/public/*", "cumo/_internal/protobuf/*"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
@@ -37,13 +34,19 @@ mypy = "^1.3.0"
 autopep8 = "^2.0.2"
 Sphinx = "^4.0.0"
 pylint = "^2.12.2"
-flake8 = {version = "^6.0.0", python = "^3.8.1"}
-mypy-protobuf = {version = "^3.5.0", python = "^3.8.1"}
+flake8 = { version = "^6.0.0", python = "^3.8.1" }
+mypy-protobuf = { version = "^3.5.0", python = "^3.8.1" }
 types-pillow = "^10.0.0.2"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"
+pattern = "^v(?P<base>\\d+\\.\\d+\\.\\d+)"
 
 [[tool.mypy.overrides]]
 module = "cumo._vendor.*"


### PR DESCRIPTION
**修正・解決されるissue**
resolve #135 

**目的**
これまでリリースの際には、pyproject.tomlを書き換えた上でタグを打ち、適切な権限を持った人間がpoetry publishし、さらにGitHubのReleaseページを更新する必要があった。

**変更点**

poetry-dynamic-versioningを利用してgitのタグからバージョンを決めるように変更。
タグを打つだけで一連の作業が自動で行われるようなworkflowを作成した。